### PR TITLE
Fix variable typo in index.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-const noImplicityAnyParams = require("./rules/no-implicit-any-params").default;
+const noImplicitAnyParams = require("./rules/no-implicit-any-params").default;
 // TODO - add each class of implicit any as an optional rule, but default is all of them on.
-const rules = { "no-implicit-any-params": noImplicityAnyParams };
+const rules = { "no-implicit-any-params": noImplicitAnyParams };
 module.exports = { rules };


### PR DESCRIPTION
## Summary
- rename `noImplicityAnyParams` variable to `noImplicitAnyParams`

## Testing
- `npm test` *(fails: jest not found)*