### PR TITLE
Fix MessageIds union type

### DIFF
--- a/rules/no-implicit-any-params.ts
+++ b/rules/no-implicit-any-params.ts
@@ -5,7 +5,7 @@ import {
 } from "@typescript-eslint/utils";
 
 export const RULE_NAME = "no-implicit-any-params";
-export type MessageIds = "noImplicitAnyRequired | else";
+export type MessageIds = "noImplicitAnyRequired" | "else";
 export type Options = [];
 
 const createRule = ESLintUtils.RuleCreator((name) => RULE_NAME);


### PR DESCRIPTION
## Summary
- fix MessageIds union type for `no-implicit-any-params` rule

## Testing
- `npm run build` *(fails: Cannot find module '@typescript-eslint/utils')*
- `npm test` *(fails: jest not found)*