### PR TITLE
Add RuleTester test for no-implicit-any-params

### DIFF
--- a/tests/no-implicit-any-params.test.ts
+++ b/tests/no-implicit-any-params.test.ts
@@ -1,3 +1,18 @@
-export const RULE_NAME = "no-implicit-any";
-export type MessageIds = "noImplicitAnyRequired";
-export type Options = [];
+import { TSESLint } from '@typescript-eslint/utils';
+import rule from '../rules/no-implicit-any-params';
+
+const ruleTester = new TSESLint.RuleTester({
+  parser: require.resolve('@typescript-eslint/parser'),
+});
+
+ruleTester.run('no-implicit-any-params', rule, {
+  valid: [
+    'function typed(a: string) {}',
+  ],
+  invalid: [
+    {
+      code: 'function untyped(a) {}',
+      errors: [{ messageId: 'noImplicitAnyRequired' }],
+    },
+  ],
+});


### PR DESCRIPTION
## Summary
- write a Jest test using `RuleTester`
- check that missing parameter annotations produce an error
- verify that typed parameters pass

## Testing
- `npm test` *(fails: jest not found)*