### PR TITLE
Update build configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "eslint-plugin-typescript-no-implicit-any",
   "version": "0.0.1",
   "main": "dist/index.js",
+  "module": "dist/index.js",
   "dependencies": {
     "@types/jest": "^28.1.4",
     "@typescript-eslint/eslint-plugin": "^5.30.5",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -26,7 +26,7 @@
 
     /* Modules */
     "module": "commonjs",                                /* Specify what module code is generated. */
-    // "rootDir": "./",                                  /* Specify the root folder within your source files. */
+    "rootDir": "./",                                     /* Specify the root folder within your source files. */
     // "moduleResolution": "node",                       /* Specify how TypeScript looks up a file from a given module specifier. */
     // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
     // "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
@@ -99,5 +99,6 @@
     /* Completeness */
     // "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
     "skipLibCheck": true                                 /* Skip type checking all .d.ts files. */
-  }
+  },
+  "include": ["rules/**/*.ts"]
 }


### PR DESCRIPTION
## Summary
- output compiled files into `dist`
- set `main` and `module` fields to use `dist` output

## Testing
- `npm test` *(fails: jest not found)*
- `npm run build` *(fails: cannot find module '@typescript-eslint/utils')*